### PR TITLE
Fix minor spelling and grammatical errors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@
 
 # Sark
 
-Sark is an application that helps you build an XCode project in your Macbook/iMac from any OS without the use of any applications. All you need is to setup your Mac and open a browser anywhere!
+Sark is an application that helps you build an Xcode project on your Mac from any OS without the use of any applications. All you need to do is set up your Mac and open a browser!
 
 
-The goal of this application is not to replace Xcode or to compete with Macbooks, we aim to help young programmers who have an iMac or know someone who does and can't afford a Macbook, we aim to help those who for some reason need to edit and test Xcode projects, but forgot their Macbook at home.
-Using Sark those people will be able to edit their project using a native application like Sublime Text using all of their computer speed and confort without needing to rely on a fast internet connection to remote access their Macs.
+The goal of this application is not to replace Xcode or to compete with Macs. Instead, we aim to help young programmers who have an iMac or know someone who does and can't afford a Macbook. We aim to help those who for some reason need to edit and test Xcode projects, but forgot their Macbook at home.
+Using Sark, those people will be able to edit their project using a native application like Sublime Text, using all of their computer's speed efficiently without needing to rely on a fast internet connection to remotely access their Macs.
 
-##How does it work?
-  
-If you follow along the usage instructions you'll notice that Sark is a Node.js server that is supposed to run on a Mac machine and be accecible through the internet. The server will execute commands and use Socket.io to communicate with the client.
+## How does it work?
+
+If you follow along the usage instructions you'll notice that Sark is a Node.js server that runs on a Mac that should be accessible through the Internet. The server will execute commands and use Socket.io to communicate with the client.
 
 ## Usage example
 
@@ -23,14 +23,14 @@ If you follow along the usage instructions you'll notice that Sark is a Node.js 
   <img align="center" src="http://i.imgur.com/Fei6XC7.png">
 </p>
 
-## What does Sark needs to run?
+## What does Sark need to run?
 
-- A Mac running OSX with Xcode installed (duh!)
+- A Mac running OS X with Xcode installed (duh!)
 - [XCPretty](https://github.com/supermarin/xcpretty)
-- [Node/NPM](https://nodejs.org/en/)
+- [Node / NPM](https://nodejs.org/en/)
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) with [cached credentials](https://help.github.com/articles/caching-your-github-password-in-git/)
 
-## How to use?
+## How to use it?
 
 #### Downloading
 
@@ -40,22 +40,22 @@ If you follow along the usage instructions you'll notice that Sark is a Node.js 
 
 #### Running the server
 
-- Leave the terminal window open, but also open Finder
-- Navigate to the created folder (uncompressed)
-- Open the file "config.json". You can open it with any text editor.
+- Leave the terminal window open, and open Finder
+- Navigate to the newly decompressed folder
+- Open the file "config.json" with any text editor.
 - Change "123" to your desired password
-- Type on terminal: 
+- Type in terminal:
 ```javascript
   gulp dev
 ```
 
-Now your server is up and running. If you go to localhost:3000 you should get the Sark's homepage. But you can't access from anywhere, so you'll need to...
+Now your server is up and running. If you go to http://localhost:3000 you should get the Sark's homepage. But if you don't have a public-facing IP, you'll need to...
 
 #### Make your Mac accessible from anywhere
 
-I like to use NoIP for a easy (and free) way to remember my iMac IP address.
+I like to use NoIP as a easy (and free) way to remember my iMac IP address.
 - [Create a NoIP account](https://www.noip.com/)
-- [Download the OSX client](https://www.noip.com/download?page=mac)
+- [Download the OS X client](https://www.noip.com/download?page=mac)
 - [Add a new host](https://www.noip.com/members/dns/host.php) (your Mac). (Almost) Like this:
 
 <p align="center">
@@ -64,14 +64,14 @@ I like to use NoIP for a easy (and free) way to remember my iMac IP address.
 
 - Open the NoIP app that you've downloaded and go to the hosts tab
 - Select the host you've created before
-- [Configure your router to do port fowarding](http://www.noip.com/support/knowledgebase/general-port-forwarding-guide/)
+- [Configure your router to do port forwarding](http://www.noip.com/support/knowledgebase/general-port-forwarding-guide/)
 
 This should get you up and running!
 
 ## I want to contribute!
-Thank you, here are some stuff that might help you:
+Thank you! Here are some things that might help you:
 
-#### Run test
+#### Running tests:
 
 - Mocha
 - Istanbul
@@ -81,13 +81,13 @@ Thank you, here are some stuff that might help you:
 > gulp test
 ```
 
-#### Run the server as development (the same as running the server for now)
+#### Running the server in development mode (the same as running the server normally for now):
 
 - Babel
 - Copy package.json to /dist
 - Copy public folder to /dist
 - Lint
-- Nodemon
+- nodemon
 
 ```javascript
 > npm install
@@ -99,11 +99,11 @@ Thank you, here are some stuff that might help you:
 #### I found a bug, what should I do?
 - Can you reproduce the bug?
 - Do you know how to fix it?
-- If you do know to fix create a pull request. If you don't create a issue on Github.
+- If you know to fix the bug, create a pull request. If you don't, create a issue on Github.
 - Do you need more help? Head over to our chat.
 
 #### Why don't you use Travis CI?
-- Sark uses a lot of specific stuff and using Travis was being more of a problem than a solution
+- Sark uses a lot of specific stuff and using Travis was becoming more of a problem than a solution.
 
 #### But don't you use Coveralls?
 - Run the tests locally and you'll see the coverage status.


### PR DESCRIPTION
This fixes some of the spelling errors and grammatical issues in the readme. It also fixes an error on the public Github Pages site where the "How does it work?" heading was not being parsed correctly due to a missing space. Hope this is helpful!

![helpful](http://i.giphy.com/xTiTnuhyBF54B852nK.gif)
